### PR TITLE
Updates the broken link on the Documentation button

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,7 +37,7 @@
           <h1>hyper <small>typed http</small></h1>
           <p>Hyper is a fast, modern HTTP implementation written in and for Rust. It is a low-level typesafe abstraction over raw HTTP, providing an elegant layer over "stringly-typed" HTTP.</p>
           <p>Hyper offers both an HTTP client and server which can be used to drive complex web applications written entirely in Rust.</p>
-          <p><a class="btn btn-primary" href="/hyper/hyper/">Documentation</a> <a class="btn btn-primary" href="https://github.com/hyperium/hyper">Source code</a></p>
+          <p><a class="btn btn-primary" href="https://hyperium.github.io/hyper">Documentation</a> <a class="btn btn-primary" href="https://github.com/hyperium/hyper">Source code</a></p>
         </div>
         <div class="col-md-6">
           <h2>Installation</h2>


### PR DESCRIPTION
The documentation button was leading to a 404 when accessing through http://hyper.rs.

This commit points the button to the same link used on the Documentation found on the navbar.