### PR TITLE
Encourage users to use (at least) version 0.9.4.

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
             <div class="panel-heading">Cargo.toml</div>
             <div class="panel-body">
               <pre><code>[dependencies]
-hyper = "0.9"
+hyper = "0.9.4"
               </code></pre>
             </div>
           </div>


### PR DESCRIPTION
Certificate validation was enabled in 0.9.4; previous versions were unsecure by default. I think it's worthwhile to be proactive about using >=0.9.4.
