### PR TITLE
Add sticky header

### DIFF
--- a/css/main.scss
+++ b/css/main.scss
@@ -55,10 +55,13 @@ pre code {
 }
 
 .navbar-hyper {
+    position: fixed;
+    background: #fff;
+    width: 100%;
+    z-index: 1;
     border: 0;
     border-bottom: 1px solid #ee9107;
     border-radius: 0;
-    margin: 0;
     padding: 0;
 }
 
@@ -91,7 +94,7 @@ pre code {
     background: $primary-pagehead-color;
     color: #fff;
     margin-bottom: 4rem;
-    padding:4rem;
+    padding: 7.375rem 4rem 4rem;
 }
 
 .hyper-home .hyper-pageheader {


### PR DESCRIPTION
Improve UX by adding a sticky header.

How it was going before:
![before](https://user-images.githubusercontent.com/8407846/28237881-45f525ec-6951-11e7-9bf7-7d9848115e14.gif)

How it will be with this patch applied:
![after](https://user-images.githubusercontent.com/8407846/28237883-4a7d6e94-6951-11e7-80b0-e5199dd4671f.gif)
