### PR TITLE
Minor edits

### DIFF
--- a/_guides/server/echo.md
+++ b/_guides/server/echo.md
@@ -116,7 +116,7 @@ First up, plain echo. Both the `Request` and the `Response` have body streams, a
 # fn main() {}
 ```
 
-Running our server now will echo the any data we `POST` to `/echo`. That was easy. What if we wanted to uppercase all the text? We could use a `map` on our streams.
+Running our server now will echo any data we `POST` to `/echo`. That was easy. What if we wanted to uppercase all the text? We could use a `map` on our streams.
 
 ### Body mapping
 
@@ -201,7 +201,7 @@ impl Service for Echo {
 
 What if we wanted our echo service to respond with the data reversed? We can't really stream the data as it comes in, since we need to find the end before we can respond. To do this, we can explore how to easily collect the full body.
 
-To try to reduce complexity for now, we'll back our uppercasing logic out, and go back to the default `Response` type.
+To reduce complexity for now, we'll back our uppercasing logic out, and go back to the default `Response` type.
 
 In this case, however, we can't really generate a `Response` immediately, but instead must wait for the full request body to be received. That means we cannot make use of the `FutureResult` as our `Service`s `Future`. That's because the type `FutureResult` is used for values that are **immediately** available. It allows wrapping up any value as a `Future`. It's something to reach for when you need to return a `Future`, but you already know the answer. In our case, we no longer do.
 


### PR DESCRIPTION
I like the minimalist approach of these articles, but I think a bit too much is omitted, even if the reader may figure this out themselves through error messages.

I would add that:

* `HelloWorld` is to be replaced by `Echo` in the `.bind()` call in `main`.
* `hyper::Body` needs to be imported
* `futures::future::FutureResult` needs to be imported
* Setting `Response = Response<Map<Body…` will break the `GET /` match in the intermediate stage of the code/article; `// only this match arm needs to change` suggests otherwise.

The bottom example doesn't compile for me, as `use futures::stream::Map` and `use futures::future::Map` clash, and disabling one or the other doesn't work either.