### PR TITLE
Add guides for handling posts and complex responses

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -12,6 +12,7 @@ hyper = "0.11.7"
 hyper-tls = "0.1"
 tokio-core = "0.1"
 serde_json = "1.0.2"
+url = "1.0"
 EOF
     cargo build --manifest-path tmp/Cargo.toml
 fi

--- a/_guides/server/handle_post.md
+++ b/_guides/server/handle_post.md
@@ -1,0 +1,241 @@
+---
+title: Handling Posts
+layout: guide
+---
+
+## Overview
+
+A common use case is to have a web page Post to the server a chunk of
+data. The data could be, for example, html form data, or Json
+submitted by XmlHttpRequest. The server will parse and validate the
+data, process it (possibly including service calls to a database or
+web service), and render a response. Responses can include web pages,
+images, or chunks of Json. A basic example of form processing is
+included in the hyper distribution,
+[params.rs](https://github.com/hyperium/hyper/blob/master/examples/params.rs). We
+will start by discussing key aspects of that example, then address how
+to modify the approach for handling other types of posted data and
+rendered responses.
+
+The basic approach to handling posts is to take the request body
+(which implements `futures::stream::Stream`) and apply a series of
+adapters until it is transformed into response future
+(`Service::Future`, which is `Box<Future<Item = Self::Response, Error
+= Self::Error>>` in the `params.rs` example). While it appears easier
+to transform the request body directly into the response body, that
+approach makes it difficult to exit early if there is a problem, such
+as a malformed request or a service is unavailable. Small quickly
+rendered response bodies can be generated as part of the response
+future. Larger responses that may take time to stream to the client
+will need to be generated in a separate stream from the response body.
+
+## Setup
+
+The basic structure of the `'params.rs` example is the same as in the
+[Echo, echo, echo](./echo) guide. Aside from handling Post, which we
+discuss below, the key differences are:
+
+Import the `url` crate for form parsing:
+
+```rust
+extern crate url;
+use url::form_urlencoded;
+# fn main() {}
+```
+
+Define some strings for the form we wish to process, and some error
+responses:
+
+```rust
+static INDEX: &[u8] = b"<html><body><form action=\"post\" method=\"post\">Name: <input type=\"text\" name=\"name\"><br>Number: <input type=\"text\" name=\"number\"><br><input type=\"submit\"></body></html>";
+static MISSING: &[u8] = b"Missing field";
+static NOTNUMERIC: &[u8] = b"Number field is not numeric";
+```
+
+## Parsing the Request Body
+
+```rust
+# extern crate futures;
+# extern crate hyper;
+# use hyper::Method::Post;
+# use hyper::{Request, Response};
+# use hyper::server::Service;
+# use futures::{Future, Stream};
+# struct ParamExample;
+# impl Service for ParamExample {
+#     type Request = Request;
+#     type Response = Response;
+#     type Error = hyper::Error;
+#     type Future = Box<Future<Item = Self::Response, Error = Self::Error>>;
+#     fn call(&self, req: Request) -> Self::Future {
+#          match (req.method(), req.path()) {
+		    (&Post, "/post") => {
+			    Box::new(req.body().concat2().
+				    map(|b| {
+					    // see below
+#					    Response::new().with_body("filler to compile")
+				    }))
+	        },
+#			(_, _) => Box::new(futures::future::ok(Response::new().with_body("filler to compile")))
+# 	    }
+# 	}
+# }
+# fn main() {}
+```
+
+First concat the request body into a future containing the entire
+request body, since we cannot do anything useful until all the data is
+available. Then we map the body into our response, which is the main
+engine of Post handling.
+
+
+```rust
+# extern crate hyper;
+# extern crate url;
+# use url::form_urlencoded;
+# use std::collections::HashMap;
+# use hyper::Chunk;
+# fn main() {
+# let b = Chunk::from("some data");
+    let params = form_urlencoded::parse(b.as_ref()).into_owned().collect::<HashMap<String, String>>();
+#	}
+```
+
+Parse the request body. `form_urlencoded::parse` always succeeds, so
+we can directly collect our form data into a HashMap. Note that this
+is a simplified use case. In principle names can appear multiple times
+in a form, and the values should be rolled up into a HashMap<String,
+Vec<String>>. However in this example the simpler approach is
+sufficient.
+
+
+```rust
+# extern crate futures;
+# extern crate hyper;
+# extern crate url;
+# use hyper::header::ContentLength;
+# use hyper::{Post, Request, Response, StatusCode};
+# use hyper::server::Service;
+# use futures::{Future, Stream};
+# use std::collections::HashMap;
+# use url::form_urlencoded;
+
+static MISSING: &[u8] = b"Missing field";
+static NOTNUMERIC: &[u8] = b"Number field is not numeric";
+
+# struct ParamExample;
+# impl Service for ParamExample {
+#     type Request = Request;
+#     type Response = Response;
+#     type Error = hyper::Error;
+#     type Future = Box<Future<Item = Self::Response, Error = Self::Error>>;
+#     fn call(&self, req: Request) -> Self::Future {
+#          match (req.method(), req.path()) {
+#		    (&Post, "/post") => {
+#			    Box::new(req.body().concat2().
+#				    map(|b| {
+#                       let params = form_urlencoded::parse(b.as_ref()).into_owned().collect::<HashMap<String, String>>();
+    let name = if let Some(n) = params.get("name") {
+        n
+    } else {
+        return Response::new()
+            .with_status(StatusCode::UnprocessableEntity)
+            .with_header(ContentLength(MISSING.len() as u64))
+            .with_body(MISSING);
+    };
+    let number = if let Some(n) = params.get("number") {
+        if let Ok(v) = n.parse::<f64>() {
+            v
+        } else {
+            return Response::new()
+                .with_status(StatusCode::UnprocessableEntity)
+                .with_header(ContentLength(NOTNUMERIC.len() as u64))
+                .with_body(NOTNUMERIC);
+        }
+    } else {
+        return Response::new()
+            .with_status(StatusCode::UnprocessableEntity)
+            .with_header(ContentLength(MISSING.len() as u64))
+            .with_body(MISSING);
+    };
+#					    Response::new().with_body("filler to compile")
+#				    }))
+#	        },
+#			(_, _) => Box::new(futures::future::ok(Response::new().with_body("filler to compile")))
+# 	    }
+# 	}
+# }
+# fn main() {}
+```
+
+Here we validate the submitted data, verifying the expected fields are
+present, and that the numeric field is in fact a number. If that is
+not the case we exit early with an appropriate `StatusCode`.
+
+### Handling Json and Other Data Types
+
+Parsing other data types follows the same pattern, although parsing
+may fail. Even if you are certain your client side code will always
+submit valid data, you have no garantee a Post came from your
+client. To parse a Json Post:
+
+```rust
+# extern crate hyper;
+# extern crate serde_json;
+# use hyper::{Response, StatusCode};
+# use hyper::header::ContentLength;
+# fn f(b: &str) -> Response {
+    let bad_request: &[u8] = b"Missing field";
+    let json: serde_json::Value = if let Ok(j) = serde_json::from_slice(b.as_ref()) {
+	    j
+    } else {
+        return Response::new()
+            .with_status(StatusCode::BadRequest)
+            .with_header(ContentLength(bad_request.len() as u64))
+            .with_body(bad_request);
+	};
+# 	Response::new().with_body("filler to compile")
+# }
+# fn main() {}
+```
+
+## Generating the Response Body
+
+```rust
+# extern crate futures;
+# extern crate hyper;
+# use hyper::Method::Post;
+# use hyper::header::ContentLength;
+# use hyper::{Request, Response};
+# use hyper::server::Service;
+# use futures::{Future, Stream};
+# struct ParamExample;
+# impl Service for ParamExample {
+#     type Request = Request;
+#     type Response = Response;
+#     type Error = hyper::Error;
+#     type Future = Box<Future<Item = Self::Response, Error = Self::Error>>;
+#     fn call(&self, req: Request) -> Self::Future {
+#          match (req.method(), req.path()) {
+#		    (&Post, "/post") => {
+#			    Box::new(req.body().concat2().
+#				    map(|b| {
+#					    let name = "M. Filler Text";
+#                       let number = 42;
+    let body = format!("Hello {}, your number is {}", name, number);
+    Response::new()
+        .with_header(ContentLength(body.len() as u64))
+        .with_body(body)
+# }))
+#	        },
+#			(_, _) => Box::new(futures::future::ok(Response::new().with_body("filler to compile")))
+# 	    }
+# 	}
+# }
+# fn main() {}
+```
+
+Finally we generate the response body. In this case the body is a
+simple string. More complex approaches, such as database queries or
+web service calls, are addressed in the [Response
+Strategies](./response_strategies) guide.

--- a/_guides/server/response_strategies.md
+++ b/_guides/server/response_strategies.md
@@ -1,0 +1,685 @@
+---
+title: Response Strategies
+layout: guide
+---
+
+## Overview
+
+The [Echo, echo, echo](./echo) guide discusses how to transform
+request bodies into response bodies, and the [Handling
+Posts](./handle_post) guide discusses processing more complex request
+bodies. We will now look into more advanced ways of generating
+responses.
+
+Two basic approaches are examined. The first handles blocking i/o or
+long processing times. These require a separate thread and the
+`futures` crate's channels. We will discuss the threaded approach in
+the context of serving files to a client, but this is readily adapted
+to database access and/or complex page rendering. A working example of
+file serving is included in the hyper distribution at
+[send_file.rs](https://github.com/hyperium/hyper/blob/master/examples/send_file.rs).
+
+The second approach illustrates how to use `tokio` aware i/o. We will
+illustrate it by accessing a simple web based api. In some ways this
+is simpler than the threaded approach, but the setup of our server is
+more complex. We will need access to the underlying `tokio` engine to
+handle our queries. A working example of web api access is included in
+the hyper distribution at
+[web_api.rs](https://github.com/hyperium/hyper/blob/master/examples/web_api.rs).
+
+We start with extracting the query information from the request (which
+can be from form parameters, cookies, headers, etc, but this guide
+will simply use the request path). This information is used to create
+the response future (`Service::Future`, which is `Box<Future<Item =
+Self::Response, Error = Self::Error>>` here). Finally, the response
+body stream is assigned.
+
+All the operations that can affect the response status code need to
+take place in the response future, not the response body stream. The
+response body stream cannot change the status of the response. For
+example, if that stream tries to open a file that does not exist, it
+cannot return a 404. The file needs to be opened before the body
+stream is created and the handle passed to the stream.
+
+## File Serving
+
+At the time of this writing, there is no cross platform way of
+accessing the filesystem with futures. We will use blocking I/O in a
+separate thread. This generalizes to anything that needs to run in a
+separate thread, such as database access or long computations.
+
+### Simple File Serving
+
+We will start with a simple approach that reads the entire file into a
+buffer. This is only appropriate for small quanities of data, such as
+a single data base row, or situations where all the long processing
+takes place before the buffer is generated.
+
+```rust
+# extern crate futures;
+# extern crate hyper;
+# use futures::Future;
+# use futures::sync::oneshot;
+# use hyper::Response;
+# use hyper::error::Error;
+# use std::io;
+# use std::thread;
+fn simple_file_send(f: &str) -> Box<Future<Item = Response, Error = hyper::Error>> {
+    let filename = f.to_string(); // we need to copy for lifetime issues
+    let (tx, rx) = oneshot::channel();
+#	thread::spawn(move || {tx.send(Response::new().with_body("filler to compile"))});
+#   Box::new(rx.map_err(|e| Error::from(io::Error::new(io::ErrorKind::Other, e))))
+# }
+# fn main() {}
+```
+
+For small files, we can do all the work with a single
+`futures::sync::oneshot::channel` to communicate with our spawned
+thread.
+
+
+```rust
+# extern crate futures;
+# extern crate hyper;
+# use futures::Future;
+# use futures::sync::oneshot;
+# use hyper::header::ContentLength;
+# use hyper::{Response, StatusCode};
+# use hyper::error::Error;
+# use std::io;
+# use std::fs::File;
+# use std::thread;
+# fn simple_file_send(f: &str) -> Box<Future<Item = Response, Error = hyper::Error>> {
+#    let filename = f.to_string(); // we need to copy for lifetime issues
+#    let (tx, rx) = oneshot::channel();
+    thread::spawn(move || {
+	    let not_found: &[u8] = b"not found";
+        let mut file = match File::open(filename) {
+            Ok(f) => f,
+            Err(_) => {
+                tx.send(Response::new()
+                        .with_status(StatusCode::NotFound)
+                        .with_header(ContentLength(not_found.len() as u64))
+                        .with_body(not_found))
+                    .expect("Send error on open");
+                return;
+            },
+        };
+#	});
+#   Box::new(rx.map_err(|e| Error::from(io::Error::new(io::ErrorKind::Other, e))))
+# }
+# fn main() {}
+```
+
+First, we attempt to open the file, returning a 404 if the file does
+not exist.
+
+```rust
+# extern crate futures;
+# extern crate hyper;
+# use futures::Future;
+# use futures::sync::oneshot;
+# use hyper::header::ContentLength;
+# use hyper::{Response, StatusCode};
+# use hyper::error::Error;
+# use std::io::{self, copy};
+# use std::fs::File;
+# use std::thread;
+# fn simple_file_send(f: &str) -> Box<Future<Item = Response, Error = hyper::Error>> {
+#    let filename = f.to_string(); // we need to copy for lifetime issues
+#    let (tx, rx) = oneshot::channel();
+#    thread::spawn(move || {
+#        let mut file = File::open(filename).unwrap();
+        let mut buf: Vec<u8> = Vec::new();
+        match copy(&mut file, &mut buf) {
+            Ok(_) => {
+                let res = Response::new()
+                    .with_header(ContentLength(buf.len() as u64))
+                    .with_body(buf);
+                tx.send(res).expect("Send error on successful file read");
+            },
+            Err(_) => {
+                tx.send(Response::new().with_status(StatusCode::InternalServerError)).
+                    expect("Send error on error reading file");
+            },
+        };
+    });
+#   Box::new(rx.map_err(|e| Error::from(io::Error::new(io::ErrorKind::Other, e))))
+# }
+# fn main() {}
+```
+
+Next we read whole file into a `Vec<u8>` buffer. We send a Response
+with the buffer as the body out the transmit channel. On an error, we
+instead return an Internal Service Error.
+
+```rust
+# extern crate futures;
+# extern crate hyper;
+# use futures::Future;
+# use futures::sync::oneshot;
+# use hyper::Response;
+# use hyper::error::Error;
+# use std::io;
+# use std::thread;
+# fn simple_file_send(f: &str) -> Box<Future<Item = Response, Error = hyper::Error>> {
+#    let filename = f.to_string(); // we need to copy for lifetime issues
+#    let (tx, rx) = oneshot::channel();
+#	thread::spawn(move || {tx.send(Response::new().with_body("filler to compile"))});
+    Box::new(rx.map_err(|e| Error::from(io::Error::new(io::ErrorKind::Other, e))))
+}
+# fn main() {}
+```
+
+Finally, we box the receive side of the channel as the Response
+future. Note that we need to map the channel's error to a
+`hyper::Error`.
+
+There are two principle drawbacks to this approach. First, since we
+read the entire file into memory, serving many large files has the
+potential to exhaust our memory. Second, we cannot start sending data
+until the file has been read, increasing the latency of our response
+for larger files.
+
+### Streaming Files
+
+We can address the problem of the single channel approach by using a
+second `mpsc::channel` to stream the file in smaller chunks. We need
+to use two channels because the Response body stream cannot change the
+status of the Response, but some i/o operations, e.g. `File::open`,
+may return errors requiring a different response. These operations all
+need to take place before the Response future is sent over the
+oneshot, before the loop that streams the Response body is started.
+
+```rust
+# extern crate futures;
+# extern crate hyper;
+# use futures::Future;
+# use futures::sync::oneshot;
+# use hyper::header::ContentLength;
+# use hyper::{Response, StatusCode};
+# use hyper::error::Error;
+# use std::io;
+# use std::fs::File;
+# use std::thread;
+fn stream_file(f: &str) -> Box<Future<Item = Response, Error = hyper::Error>> {
+    let filename = f.to_string(); // we need to copy for lifetime issues
+    let (tx, rx) = oneshot::channel();
+    thread::spawn(move || {
+	    let not_found: &[u8] = b"not found";
+        let mut file = match File::open(filename) {
+            Ok(f) => f,
+            Err(_) => {
+                tx.send(Response::new()
+                        .with_status(StatusCode::NotFound)
+                        .with_header(ContentLength(not_found.len() as u64))
+                        .with_body(not_found))
+                    .expect("Send error on open");
+                return;
+            },
+        };
+#	});
+#   Box::new(rx.map_err(|e| Error::from(io::Error::new(io::ErrorKind::Other, e))))
+# }
+# fn main() {}
+```
+
+We begin the same as the simple approach.
+
+```rust
+# extern crate futures;
+# extern crate hyper;
+# use futures::Future;
+# use futures::sync::{mpsc, oneshot};
+# use hyper::header::ContentLength;
+# use hyper::{Response, StatusCode};
+# use hyper::error::Error;
+# use std::io::{self, copy};
+# use std::fs::File;
+# use std::thread;
+# fn simple_file_send(f: &str) -> Box<Future<Item = Response, Error = hyper::Error>> {
+#    let filename = f.to_string(); // we need to copy for lifetime issues
+#    let (tx, rx) = oneshot::channel();
+#    thread::spawn(move || {
+#        let mut file = File::open(filename).unwrap();
+        let (mut tx_body, rx_body) = mpsc::channel(1);
+        let res = Response::new().with_body(rx_body);
+        tx.send(res).expect("Send error on successful file read");
+#	});
+#   Box::new(rx.map_err(|e| Error::from(io::Error::new(io::ErrorKind::Other, e))))
+# }
+# fn main() {}
+```
+
+Here we create an `mpsc::channel` for the response body. We create a
+Response with the receive side of the `mpsc::channel` as the body, and
+send it out the `oneshot::channel`.
+
+
+```rust
+# extern crate futures;
+# extern crate hyper;
+# use futures::{Future, Sink};
+# use futures::sync::{mpsc, oneshot};
+# use hyper::header::ContentLength;
+# use hyper::{Chunk, Response, StatusCode};
+# use hyper::error::Error;
+# use std::io::{self, Read};
+# use std::fs::File;
+# use std::thread;
+# fn simple_file_send(f: &str) -> Box<Future<Item = Response, Error = hyper::Error>> {
+#    let filename = f.to_string(); // we need to copy for lifetime issues
+#    let (tx, rx) = oneshot::channel();
+#    thread::spawn(move || {
+#        let mut file = File::open(filename).unwrap();
+#        let (mut tx_body, rx_body) = mpsc::channel(1);
+#        let res = Response::new().with_body(rx_body);
+#        tx.send(res).expect("Send error on successful file read");
+        let mut buf = [0u8; 4096];
+        loop {
+            match file.read(&mut buf) {
+                Ok(n) => {
+                    if n == 0 {
+                        // eof
+                        tx_body.close().expect("panic closing");
+                        break;
+                    } else {
+                        let chunk: Chunk = buf.to_vec().into();
+                        match tx_body.send(Ok(chunk)).wait() {
+                            Ok(t) => { tx_body = t; },
+                            Err(_) => { break; }
+                        };
+                    }
+                },
+                Err(_) => { break; }
+            }
+        }
+    });
+    Box::new(rx.map_err(|e| Error::from(io::Error::new(io::ErrorKind::Other, e))))
+}
+# fn main() {}
+```
+
+We create a buffer, and loop through file sending buffer sized chunks
+until we reach the end of the file. On errors we simply exit the
+thread, but in practice some sort of logging would be appropriate.
+Finally, we box up the receive channel of the oneshot as in the simple
+case.
+
+When in doubt, use the two channel streaming approach. This will work
+with small data quanities at a small overhead cost, and scale safely
+to large quantities of data.
+
+## Web Services
+
+Using `tokio` aware i/o removes the need for separate
+threads. However, building the server is more complex so we can pass a
+handle to the tokio reactor to our service. Our service needs this
+handle to launch `tokio` based i/o.
+
+Mapping the responses to our web queries to the bodies of our
+responses does not result in a `hyper::Body`. The most straightforward
+way of dealing with this is to use a trait object as the body type of
+our Service::Response.
+
+### The ResponseExamples Service
+
+We need a handle to a tokio reactor to create web queries, so we make
+it part of our `Service`:
+
+```rust
+# extern crate tokio_core;
+struct ResponseExamples(tokio_core::reactor::Handle);
+```
+
+The various transforms we need to perfom on our web request streams to
+get to our response body streams result in some fairly complex
+types. The easiest way to deal with these is to define our
+Service::Response to use a trait object instead of `hyper::Body`. Our
+code will be more clear if we define this as a type:
+
+```rust
+# extern crate futures;
+# extern crate hyper;
+# extern crate tokio_core;
+# use futures::{Future, Stream};
+# use hyper::{Body, Chunk, Request, Response, Error};
+# use hyper::server::Service;
+pub type ResponseStream = Box<Stream<Item=Chunk, Error=Error>>;
+
+# struct ResponseExamples(tokio_core::reactor::Handle);
+impl Service for ResponseExamples {
+    type Request = Request;
+    type Response = Response<ResponseStream>;
+    type Error = hyper::Error;
+    type Future = Box<Future<Item = Self::Response, Error = Self::Error>>;
+#    fn call(&self, req: Request) -> Self::Future {
+#        let body: ResponseStream = Box::new(Body::from("filler to compile"));
+#        Box::new(futures::future::ok(Response::new().with_body(body)))
+#    }
+# }
+# fn main() {}
+```
+
+Since `hyper::Body` implements `Stream<Item=Chunk, Error=Error>`, it
+can be easily converted to this type with `Box`, for example:
+
+```rust
+# extern crate futures;
+# extern crate hyper;
+# use futures::Stream;
+# use hyper::{Body, Chunk, Error};
+# pub type ResponseStream = Box<Stream<Item=Chunk, Error=Error>>;
+# fn main() {
+let body: ResponseStream = Box::new(Body::from("A simple response"));
+# }
+```
+
+#### /web_api
+
+For the purposes of this example, we will include a web api to test
+against, but normally one would connect to a different service. Our
+web api is a simple uppercasing as discussed in [Echo, echo,
+echo](./echo):
+
+```rust
+# extern crate futures;
+# extern crate hyper;
+# extern crate tokio_core;
+# use futures::{Future, Stream};
+# use hyper::{Body, Chunk, Post, Request, Response, Error};
+# use hyper::server::Service;
+# use std::ascii::AsciiExt;
+# pub type ResponseStream = Box<Stream<Item=Chunk, Error=Error>>;
+# struct ResponseExamples(tokio_core::reactor::Handle);
+# impl Service for ResponseExamples {
+#    type Request = Request;
+#    type Response = Response<ResponseStream>;
+#    type Error = hyper::Error;
+#    type Future = Box<Future<Item = Self::Response, Error = Self::Error>>;
+#    fn call(&self, req: Request) -> Self::Future {
+#          match (req.method(), req.path()) {
+            (&Post, "/web_api") => {
+                let body: ResponseStream = Box::new(req.body().map(|chunk| {
+                    let upper = chunk.iter()
+                        .map(|byte| byte.to_ascii_uppercase())
+                        .collect::<Vec<u8>>();
+                    Chunk::from(upper)
+                }));
+                Box::new(futures::future::ok(Response::new().with_body(body)))
+            },
+#			(_, _) => {
+#               let body: ResponseStream = Box::new(Body::from("filler to compile"));
+#               Box::new(futures::future::ok(Response::new().with_body(body)))
+#           }
+# 	    }
+# 	}
+# }
+# fn main() {}
+```
+
+#### /test.html
+
+Here we make our query to a web service.
+
+```rust
+# extern crate futures;
+# extern crate hyper;
+# extern crate tokio_core;
+# use futures::{Future, Stream};
+# use hyper::{Body, Chunk, Client, Get, Post, Request, Response, Error};
+# use hyper::server::Service;
+# pub type ResponseStream = Box<Stream<Item=Chunk, Error=Error>>;
+static LOWERCASE: &[u8] = b"i am a lower case string";
+
+# struct ResponseExamples(tokio_core::reactor::Handle);
+# impl Service for ResponseExamples {
+#    type Request = Request;
+#    type Response = Response<ResponseStream>;
+#    type Error = hyper::Error;
+#    type Future = Box<Future<Item = Self::Response, Error = Self::Error>>;
+#    fn call(&self, req: Request) -> Self::Future {
+#          match (req.method(), req.path()) {
+            (&Get, "/test.html") => {
+                let client = Client::configure().build(&self.0);
+                let mut req = Request::new(Post, "http://127.0.0.1:1337/web_api".parse().unwrap());
+                req.set_body(LOWERCASE);
+                let web_res_future = client.request(req);
+#                Box::new(web_res_future.map(|web_res| {
+#                    let body: ResponseStream = Box::new(web_res.body().map(|b| {
+#                        Chunk::from(format!("before: '{:?}'<br>after: '{:?}'",
+#                                            std::str::from_utf8(LOWERCASE).unwrap(),
+#                                            std::str::from_utf8(&b).unwrap()))
+#                    }));
+#                    Response::new().with_body(body)
+#                }))
+#            },
+#			(_, _) => {
+#               let body: ResponseStream = Box::new(Body::from("filler to compile"));
+#               Box::new(futures::future::ok(Response::new().with_body(body)))
+#           }
+# 	    }
+# 	}
+# }
+# fn main() {}
+```
+
+We start by creating a hyper client with a post request. Client
+programming is discussed in detail in the Client portion of these
+guides. The [Advanced Client Usage](../client/advanced) page discusses
+how to create and process Posts. Since we already have a handle to the
+tokio reactor, we do not need to create one here. `web_res_future` is
+a Future containing the results of our query.
+
+```rust
+# extern crate futures;
+# extern crate hyper;
+# extern crate tokio_core;
+# use futures::{Future, Stream};
+# use hyper::{Body, Chunk, Client, Get, Post, Request, Response, Error};
+# use hyper::server::Service;
+# pub type ResponseStream = Box<Stream<Item=Chunk, Error=Error>>;
+# static LOWERCASE: &[u8] = b"i am a lower case string";
+# struct ResponseExamples(tokio_core::reactor::Handle);
+# impl Service for ResponseExamples {
+#    type Request = Request;
+#    type Response = Response<ResponseStream>;
+#    type Error = hyper::Error;
+#    type Future = Box<Future<Item = Self::Response, Error = Self::Error>>;
+#    fn call(&self, req: Request) -> Self::Future {
+#          match (req.method(), req.path()) {
+#            (&Get, "/test.html") => {
+#                let lowercase = b"i am a lower case string";
+#                let client = Client::configure().build(&self.0);
+#                let mut req = Request::new(Post, "http://127.0.0.1:1337/web_api".parse().unwrap());
+#                req.set_body(LOWERCASE);
+#                let web_res_future = client.request(req);
+                Box::new(web_res_future.map(|web_res| {
+                    let body: ResponseStream = Box::new(web_res.body().map(|b| {
+                        Chunk::from(format!("before: '{:?}'<br>after: '{:?}'",
+                                            std::str::from_utf8(LOWERCASE).unwrap(),
+                                            std::str::from_utf8(&b).unwrap()))
+                    }));
+                    Response::new().with_body(body)
+                }))
+            },
+#			(_, _) => {
+#               let body: ResponseStream = Box::new(Body::from("filler to compile"));
+#               Box::new(futures::future::ok(Response::new().with_body(body)))
+#           }
+# 	    }
+# 	}
+# }
+# fn main() {}
+```
+
+Here we map the `web_res_future` into a `Response`. Within that
+mapping, we map the web query's body into a body for our
+`Response`. In this case it is a simple before and after
+comparison. We `Box` the `Response` and return it as our result.
+
+In this example, any errors in `web_res_future` are simply passed on
+in our response. More robust design would unpack those errors and set
+appropriate status codes. Retries or default responses may also be
+implemented depending on the application.
+
+### Building the Server
+
+In earlier examples, we could let Http::bind take care of creating and
+running the tokio objects. However, since we wish to create outgoing
+http connections in addition to handling incoming, we need to set
+things up ourselves.
+
+```rust,no_run
+# extern crate futures;
+# extern crate hyper;
+# extern crate tokio_core;
+# use futures::{Future, Stream};
+# use hyper::{Body, Chunk, Request, Response, Error};
+# use hyper::server::{Http, Service};
+# pub type ResponseStream = Box<Stream<Item=Chunk, Error=Error>>;
+# struct ResponseExamples(tokio_core::reactor::Handle);
+# impl Service for ResponseExamples {
+#    type Request = Request;
+#    type Response = Response<ResponseStream>;
+#    type Error = hyper::Error;
+#    type Future = Box<Future<Item = Self::Response, Error = Self::Error>>;
+#    fn call(&self, req: Request) -> Self::Future {
+#        let body: ResponseStream = Box::new(Body::from("filler to compile"));
+#        Box::new(futures::future::ok(Response::new().with_body(body)))
+#    }
+# }
+# fn main() {
+    let addr = "127.0.0.1:1337".parse().unwrap();
+    let mut core = tokio_core::reactor::Core::new().unwrap();
+    let server_handle = core.handle();
+    let client_handle = core.handle();
+#    let serve = Http::new().serve_addr_handle(&addr, &server_handle, move || Ok(ResponseExamples(client_handle.clone()))).unwrap();
+#    println!("Listening on http://{} with 1 thread.", serve.incoming_ref().local_addr());
+#    let h2 = server_handle.clone();
+#    server_handle.spawn(serve.for_each(move |conn| {
+#        h2.spawn(conn.map(|_| ()).map_err(|err| println!("serve error: {:?}", err)));
+#        Ok(())
+#    }).map_err(|_| ()));
+#    core.run(futures::future::empty::<(), ()>()).unwrap();
+# }
+```
+
+Create the tokio core. `server_handle` is for server support handled
+by `Http::bind` in other guides. `client_handle` is the `Core` handle
+that we will use when creating web requests.
+
+```rust,no_run
+# extern crate futures;
+# extern crate hyper;
+# extern crate tokio_core;
+# use futures::{Future, Stream};
+# use hyper::{Body, Chunk, Request, Response, Error};
+# use hyper::server::{Http, Service};
+# pub type ResponseStream = Box<Stream<Item=Chunk, Error=Error>>;
+# struct ResponseExamples(tokio_core::reactor::Handle);
+# impl Service for ResponseExamples {
+#    type Request = Request;
+#    type Response = Response<ResponseStream>;
+#    type Error = hyper::Error;
+#    type Future = Box<Future<Item = Self::Response, Error = Self::Error>>;
+#    fn call(&self, req: Request) -> Self::Future {
+#        let body: ResponseStream = Box::new(Body::from("filler to compile"));
+#        Box::new(futures::future::ok(Response::new().with_body(body)))
+#    }
+# }
+# fn main() {
+#    let addr = "127.0.0.1:1337".parse().unwrap();
+#    let mut core = tokio_core::reactor::Core::new().unwrap();
+#    let server_handle = core.handle();
+#    let client_handle = core.handle();
+    let serve = Http::new().serve_addr_handle(&addr, &server_handle, move || Ok(ResponseExamples(client_handle.clone()))).unwrap();
+    println!("Listening on http://{} with 1 thread.", serve.incoming_ref().local_addr());
+#    let h2 = server_handle.clone();
+#    server_handle.spawn(serve.for_each(move |conn| {
+#        h2.spawn(conn.map(|_| ()).map_err(|err| println!("serve error: {:?}", err)));
+#        Ok(())
+#    }).map_err(|_| ()));
+#    core.run(futures::future::empty::<(), ()>()).unwrap();
+# }
+```
+
+Set up the `serve` `Stream`, which is a `futures::stream::Stream` of
+`Connections`.
+
+
+```rust,no_run
+# extern crate futures;
+# extern crate hyper;
+# extern crate tokio_core;
+# use futures::{Future, Stream};
+# use hyper::{Body, Chunk, Request, Response, Error};
+# use hyper::server::{Http, Service};
+# pub type ResponseStream = Box<Stream<Item=Chunk, Error=Error>>;
+# struct ResponseExamples(tokio_core::reactor::Handle);
+# impl Service for ResponseExamples {
+#    type Request = Request;
+#    type Response = Response<ResponseStream>;
+#    type Error = hyper::Error;
+#    type Future = Box<Future<Item = Self::Response, Error = Self::Error>>;
+#    fn call(&self, req: Request) -> Self::Future {
+#        let body: ResponseStream = Box::new(Body::from("filler to compile"));
+#        Box::new(futures::future::ok(Response::new().with_body(body)))
+#    }
+# }
+# fn main() {
+#    let addr = "127.0.0.1:1337".parse().unwrap();
+#    let mut core = tokio_core::reactor::Core::new().unwrap();
+#    let server_handle = core.handle();
+#    let client_handle = core.handle();
+#    let serve = Http::new().serve_addr_handle(&addr, &server_handle, move || Ok(ResponseExamples(client_handle.clone()))).unwrap();
+#    println!("Listening on http://{} with 1 thread.", serve.incoming_ref().local_addr());
+    let h2 = server_handle.clone();
+    server_handle.spawn(serve.for_each(move |conn| {
+        h2.spawn(conn.map(|_| ()).map_err(|err| println!("serve error: {:?}", err)));
+        Ok(())
+    }).map_err(|_| ()));
+#    core.run(futures::future::empty::<(), ()>()).unwrap();
+# }
+```
+
+Set up processing for each incoming connection.
+
+
+```rust,no_run
+# extern crate futures;
+# extern crate hyper;
+# extern crate tokio_core;
+# use futures::{Future, Stream};
+# use hyper::{Body, Chunk, Request, Response, Error};
+# use hyper::server::{Http, Service};
+# pub type ResponseStream = Box<Stream<Item=Chunk, Error=Error>>;
+# struct ResponseExamples(tokio_core::reactor::Handle);
+# impl Service for ResponseExamples {
+#    type Request = Request;
+#    type Response = Response<ResponseStream>;
+#    type Error = hyper::Error;
+#    type Future = Box<Future<Item = Self::Response, Error = Self::Error>>;
+#    fn call(&self, req: Request) -> Self::Future {
+#        let body: ResponseStream = Box::new(Body::from("filler to compile"));
+#        Box::new(futures::future::ok(Response::new().with_body(body)))
+#    }
+# }
+# fn main() {
+#    let addr = "127.0.0.1:1337".parse().unwrap();
+#    let mut core = tokio_core::reactor::Core::new().unwrap();
+#    let server_handle = core.handle();
+#    let client_handle = core.handle();
+#    let serve = Http::new().serve_addr_handle(&addr, &server_handle, move || Ok(ResponseExamples(client_handle.clone()))).unwrap();
+#    println!("Listening on http://{} with 1 thread.", serve.incoming_ref().local_addr());
+#    let h2 = server_handle.clone();
+#    server_handle.spawn(serve.for_each(move |conn| {
+#        h2.spawn(conn.map(|_| ()).map_err(|err| println!("serve error: {:?}", err)));
+#        Ok(())
+#    }).map_err(|_| ()));
+    core.run(futures::future::empty::<(), ()>()).unwrap();
+
+# }
+```
+
+Run the Core to listen for connections.


### PR DESCRIPTION
Here are a couple server guide pages to go with the examples I recently contributed. It wasn't clear to me how to add them to the table of contents on the guide pages. Am I missing something, or is it automatic?

The last section of response_strategies.md, on building the server, feels weak to me. I'm not very familiar with the working of tokio, so a close reading there would be appreciated.

I think a final page about tying it all together is needed. I kept the file serving and web api examples separate because I found needed type conversions when they were combined obscured the main point of the examples. Adding in Post handling will add further conversions. I suspect that in moderately complex applications, the cleanest approach will be to define wrapper structs for Service::Response and Service::Future. Those can implement From for a range of types to remove a bunch of type conversion clutter. I'm not confident about that yet, so don't feel comfortable writing it. I hope to return to migrating nickel.rs soon, and I should understand things much better after that.