### PR TITLE
Fix broken links with Jekyll Relative Links

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -24,6 +24,10 @@ kramdown:
     input: GFM
     syntax_highlighter: rouge
 
+relative_links:
+  enabled: true
+  collections: true
+
 docs_url: https://docs.rs/hyper/*
 futures_url: https://docs.rs/futures/*
 tokio_core_url: https://docs.rs/tokio-core/*

--- a/_guides/index.md
+++ b/_guides/index.md
@@ -19,5 +19,5 @@ hyper = "0.11"
 You could also look at the [generated API documentaton][docs].
 
 [docs]: {{ site.docs_url }}
-[Server guide]: ./server/hello-world
-[Client guide]: ./client/basic
+[Server guide]: server/hello-world.md
+[Client guide]: client/basic.md

--- a/_guides/server/echo.md
+++ b/_guides/server/echo.md
@@ -2,7 +2,7 @@
 title: Echo, echo, echo
 ---
 
-You already have a [Hello World server](./index)? Excellent! Usually,
+You already have a [Hello World server](hello-world.md)? Excellent! Usually,
 servers do more than just spit out the same body for every request. To
 exercise several more parts of hyper, this guide will go through
 building an echo server.

--- a/_guides/server/handle_post.md
+++ b/_guides/server/handle_post.md
@@ -32,7 +32,7 @@ will need to be generated in a separate stream from the response body.
 ## Setup
 
 The basic structure of the `'params.rs` example is the same as in the
-[Echo, echo, echo](./echo) guide. Aside from handling Post, which we
+[Echo, echo, echo](echo.md) guide. Aside from handling Post, which we
 discuss below, the key differences are:
 
 Import the `url` crate for form parsing:
@@ -238,4 +238,4 @@ client. To parse a Json Post:
 Finally we generate the response body. In this case the body is a
 simple string. More complex approaches, such as database queries or
 web service calls, are addressed in the [Response
-Strategies](./response_strategies) guide.
+Strategies](response_strategies.md) guide.

--- a/_guides/server/response_strategies.md
+++ b/_guides/server/response_strategies.md
@@ -5,9 +5,9 @@ layout: guide
 
 ## Overview
 
-The [Echo, echo, echo](./echo) guide discusses how to transform
+The [Echo, echo, echo](echo.md) guide discusses how to transform
 request bodies into response bodies, and the [Handling
-Posts](./handle_post) guide discusses processing more complex request
+Posts](handle_post.md) guide discusses processing more complex request
 bodies. We will now look into more advanced ways of generating
 responses.
 
@@ -380,7 +380,7 @@ let body: ResponseStream = Box::new(Body::from("A simple response"));
 For the purposes of this example, we will include a web api to test
 against, but normally one would connect to a different service. Our
 web api is a simple uppercasing as discussed in [Echo, echo,
-echo](./echo):
+echo](echo.md):
 
 ```rust
 # extern crate futures;
@@ -466,7 +466,7 @@ static LOWERCASE: &[u8] = b"i am a lower case string";
 
 We start by creating a hyper client with a post request. Client
 programming is discussed in detail in the Client portion of these
-guides. The [Advanced Client Usage](../client/advanced) page discusses
+guides. The [Advanced Client Usage](../client/advanced.md) page discusses
 how to create and process Posts. Since we already have a handle to the
 tokio reactor, we do not need to create one here. `web_res_future` is
 a Future containing the results of our query.


### PR DESCRIPTION
While reading the guides, I noticed that multiple links were broken. As @adrian5 pointed out in #15, the link to the *Hello, world!* example on the [*Echo, echo, echo* page](https://hyper.rs/guides/server/echo/index) directs to [itself](https://hyper.rs/guides/server/echo/index) rather than the actual [*Hello, world!* page](https://hyper.rs/guides/server/hello-world/). Multiple more links are affected as well.

First, I wanted to fix this by prefixing all URLs with `../`. This would fix the HTMLs links generated by Jekyll. But as @jolhoeft objected in #24, this would break all links when reading the Markdown files on github.com.

Both problems are solved by using the [Jekyll Relative Links plug-in][1] and directly linking to the Markdown files with their `.md` extension. With this plug-in, Jekyll automatically makes links to the Markdown files point to the correct HTML-rendered locations. At the same time, the links on github.com are still working, because they can now point to the actual file locations.

Note that the Jekyll Relative Links plug-in is enabled by default on all GitHub Pages builds. The idea stems from Ben Balter at GitHub (@benbalter), who also wrote a [blog post on that topic][2].

This commit adds the necessary piece of configuration to make use of the Jekyll Relative Links plug-in. Note that it explicitly needs to be turned on for collections—otherwise, it wouldn’t work within the guides. Additionally, this commit makes all guide links point to the respective Markdown files.

I verified this solution by publishing my fork with GitHub Pages. Links are correct both when browsing the Jekyll-rendered guides and when reading the Markdown files directly on github.com.

Fixes #15 and fixes #24.

[1]:https://github.com/benbalter/jekyll-relative-links
[2]:https://github.com/blog/2290-relative-links-for-github-pages