### PR TITLE
WIP: port examples to 0.12.x

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -8,8 +8,8 @@ if [ ! -e tmp/Cargo.toml ]; then
     fi
     cat >> tmp/Cargo.toml <<-EOF
 futures = "0.1.14"
-hyper = "0.11.7"
-hyper-tls = "0.1"
+hyper =  { git = "https://github.com/hyperium/hyper"}
+hyper-tls =  { git = "https://github.com/hyperium/hyper-tls"}
 tokio-core = "0.1"
 serde_json = "1.0.2"
 url = "1.0"


### PR DESCRIPTION
This is a WIP branch of trying to port all of the examples to tokio 0.12

The eventual aim is to address https://github.com/hyperium/hyper/issues/1463 but for now I'm just blasting through a file at a time, and making the tests pass.

My current workflow is:

```
rm tmp/Cargo.toml
./.travis.sh
# billions of errors flash past

while watchman-wait .; do rustdoc -L tmp/target/debug/deps --test /Users/alsuresrc/hyperium.github.io/_guides/client/advanced.md ; done
```

If other people want to help out, it's probably worth creating an upstream 0.12.x staging branch, but I will happily merge any PRs made against my 0.12.x branch in the meantime.