### PR TITLE
Fix casing on 'echo' guide

### DIFF
--- a/_guides/server/echo.md
+++ b/_guides/server/echo.md
@@ -32,7 +32,7 @@ Then, we need to add some to our imports:
 # extern crate hyper;
 extern crate futures;
 
-use futures::Future;
+use futures::future;
 use hyper::{Method, StatusCode};
 # fn main() {}
 ```


### PR DESCRIPTION
I went through the Hyper 0.12 guide today and hit this snag.

The example wants to call `futures::future::ok`, but imports `futures::Future` instead of `futures::future`. The former is a type, which collides with a type imported in the previous guide and the latter is a module containing the function we want.