### PR TITLE
Update doc link to Service trait

### DIFF
--- a/_guides/server/hello-world.md
+++ b/_guides/server/hello-world.md
@@ -95,5 +95,5 @@ hyper::rt::run(server);
 
 To see all the snippets put together, check out the [full example][example]!
 
-[service]: {{ site.docs_url }}/hyper/trait.Service.html
+[service]: {{ site.docs_url }}/hyper/service/trait.Service.html
 [example]: {{ site.examples_url }}/hello.rs


### PR DESCRIPTION
I suppose the doc link to [Service](https://docs.rs/hyper/0.12.33/hyper/service/trait.Service.html) trait should be updated to point to `/hyper/service/trait.Service.html` instead of `/hyper/trait.Service.html`.