### PR TITLE
Added missing imports to advanced client documentation

### DIFF
--- a/_guides/client/advanced.md
+++ b/_guides/client/advanced.md
@@ -14,7 +14,8 @@ that's what we'll do.
 
 ```rust
 # extern crate hyper;
-use hyper::{Method, Request};
+use hyper::header::HeaderValue;
+use hyper::{Body, Method, Request};
 # fn main() {}
 ```
 


### PR DESCRIPTION
A user who goes through the client tutorials step-by-step will end up with code that doesn't compile because there are some imports missing. This adds the missing imports so that the code will compile and run.