### PR TITLE
Fix a pair of broken links in the Advanced Client Usage guide

### DIFF
--- a/_guides/client/advanced.md
+++ b/_guides/client/advanced.md
@@ -153,6 +153,6 @@ work
 Last step, we are just printing them to stdout.
 
 [simple guide]: ./basic.md
-[Request]: {{ site.docs_url }}/hyper/client/struct.Request.html
-[Method]: {{ site.docs_url }}/hyper/enum.Method.html
+[Request]: {{ site.docs_url }}/hyper/struct.Request.html
+[Method]: {{ site.docs_url }}/hyper/struct.Method.html
 [Join]: {{ site.futures_url }}/futures/future/trait.Future.html#method.join


### PR DESCRIPTION
Both of these links are broken in the published version: https://hyper.rs/guides/client/advanced/