### PR TITLE
Update *Blazing fast* link to newest TechEmpower round

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -19,7 +19,7 @@
         <ul>
             <li>A <strong>Client</strong> for talking to web services.</li>
             <li>A <strong>Server</strong> for building those web services.</li>
-            <li>Blazing <strong>fast</strong><a href="https://www.techempower.com/benchmarks/#section=data-r15&hw=ph&test=plaintext">*</a> thanks to Rust.</li>
+            <li>Blazing <strong>fast</strong><a href="https://www.techempower.com/benchmarks/#section=data-r18&hw=ph&test=plaintext">*</a> thanks to Rust.</li>
             <li>High <strong>concurrency</strong> with non-blocking sockets.</li>
             <li>HTTP/1 and <strong>HTTP/2</strong> support.</li>
         </ul>


### PR DESCRIPTION
Very minor but noticed that the link to TechEmpower was from Round 15 where the most recent version is Round 18. Hyper is in position 1 for Round 18 plaintext so it seems suitable for the argument being made about Hyper's speed.