### PR TITLE
Fixed typo in advanced guide Cargo.toml example

### DIFF
--- a/_guides/client/advanced.md
+++ b/_guides/client/advanced.md
@@ -78,7 +78,7 @@ imports again:
 ```toml
 [dependencies]
 hyper = "0.13"
-tokio = { version = "0.2", features = ["full'} }
+tokio = { version = "0.2", features = ["full"] }
 futures = "0.3"
 ```
 


### PR DESCRIPTION
Previously `}` was used instead of `]` at the end of the displayed feature list.