### PR TITLE
Fix hyper::Client links

### DIFF
--- a/_guides/client/basic.md
+++ b/_guides/client/basic.md
@@ -117,7 +117,7 @@ while let Some(chunk) = resp.body_mut().data().await {
 
 And that's it! You can see the [full example here][example].
 
-[Client]: {{ site.docs_url }}/hyper/struct.Client.html
+[Client]: {{ site.docs_url }}/hyper/client/struct.Client.html
 [Tokio]: https://tokio.rs
 [Tokio-Futures]: https://tokio.rs/docs/getting-started/futures/
 [StatusCode]: {{ site.docs_url }}/hyper/struct.StatusCode.html

--- a/_guides/client/configuration.md
+++ b/_guides/client/configuration.md
@@ -39,5 +39,5 @@ ideas of things that could be connectors:
 - Proxies
 - In-memory streams (such as for testing)
 
-[`Client`]: {{ site.docs_url }}/hyper/struct.Client.html
+[`Client`]: {{ site.docs_url }}/hyper/client/struct.Client.html
 [hyper-tls]: {{ site.hyper_tls_url }}


### PR DESCRIPTION
While reading the client documentation I noticed that attempting to follow the links for [`hyper::Client`](https://docs.rs/hyper/0.13.1/hyper/struct.Client.html) on the [basic](https://hyper.rs/guides/client/basic/) and [configuration](https://hyper.rs/guides/client/configuration/) pages results in an error that says _"The requested resource does not exist"_

![the-requested-resource-does-not-exist](https://user-images.githubusercontent.com/3084059/73141308-95461b00-4037-11ea-99cb-1681821ffda5.png)

If you attempt to fetch the page, you get a **404** error.

```shell
[12:39:39] tucker@oryoki:~ § url='https://docs.rs/hyper/0.13.1/hyper/struct.Client.html'
[12:39:40] tucker@oryoki:~ § curl --silent --head --fail $url                                           
curl: (22) The requested URL returned error: 404
```

If you add the full path to [`hyper::client::Client`](https://docs.rs/hyper/0.13.1/hyper/client/struct.Client.html), then the docs load correctly.

```shell
[12:40:48] tucker@oryoki:~ § url='https://docs.rs/hyper/0.13.1/hyper/client/struct.Client.html'
[12:40:52] tucker@oryoki:~ § curl --silent --head --fail $url | grep 200              
HTTP/2 200
```

This PR attempts to fix the aforementioned issue by using the full path so that users will be directed to the correct page.