### PR TITLE
Add link to edit on GitHub

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,6 +1,13 @@
 <footer class="hyper-footer col-md-12">
-    <div class="container text-muted">
-        &copy; 2019 hyper
+    <div class="container">
+        <div class="row">
+            <div class="col-sm-6 text-center text-sm-left text-muted">&copy; 2019 hyper</div>
+            <div class="col-sm-6 text-center text-sm-right">
+                <a href="https://github.com/hyperium/hyperium.github.io/blob/master/{{ page.path }}">
+                    edit this page on github
+                </a>
+            </div>
+        </div>
     </div>
 </footer>
 <script src="{{ "/js/rustdoc.js" | absolute_url }}"></script>


### PR DESCRIPTION
To allow for easier editing of pages by the community, adds a link to all pages
(using _includes/footer.html) that links to the corresponding file in the
GitHub repo.

Fixes https://github.com/hyperium/hyper/issues/2131.