### PR TITLE
Make basic guide code more consistent to avoid errors

### DIFF
--- a/_guides/client/basic.md
+++ b/_guides/client/basic.md
@@ -71,7 +71,7 @@ let client = Client::new();
 let uri = "http://httpbin.org/ip".parse()?;
 
 // Await the response...
-let resp = client.get(uri).await?;
+let mut resp = client.get(uri).await?;
 
 println!("Response: {}", resp.status());
 # Ok(())


### PR DESCRIPTION
Changes `resp` to be mutable in the first example too so the code matches the one below. Following the tutorial I got an error, because the second code sample was subtly different.