### PR TITLE
update dependencies to make server compile

### DIFF
--- a/_guides/server/echo.md
+++ b/_guides/server/echo.md
@@ -17,14 +17,14 @@ routing. We want to have a route explaining instructions on how to use
 our server, and another for receiving data. Oh, and we should also
 handle the case when someone asks for a route we don't know!
 
-We're going to be using more of the [futures][future-crate] crate, so let's add
+We're going to be using more of the [futures_util-crate][futures_util-crate] crate, so let's add
 that as a dependency:
 
 ```toml
 [dependencies]
 hyper = "0.13"
 tokio = { version = "0.2", features = ["full"] }
-futures = "0.3"
+futures-util = "0.3.5"
 ```
 
 Then, we need to add some to our imports:
@@ -198,4 +198,4 @@ We want to concatenate the request body, and map the result into our `reverse` f
 You can see a compiling [example here][example].
 
 [example]: {{ site.examples_url }}/echo.rs
-[future-crate]: https://github.com/rust-lang-nursery/futures-rs
+[futures_util-crate]: https://github.com/rust-lang/futures-rs/tree/master/futures-util


### PR DESCRIPTION
## Before
The example was not compiling
```
cargo run
 --> example/simple_experiment/src/main.rs:2:5
  |
2 | use futures_util::TryStreamExt;
  |     ^^^^^^^^^^^^ use of undeclared type or module `futures_util`

error[E0599]: no method named `map_ok` found for struct `hyper::body::body::Body` in the current scope
  --> example/simple_experiment/src/main.rs:20:48
   |
20 |             let chunk_stream = req.into_body().map_ok(|chunk| {
   |                                                ^^^^^^ method not found in `hyper::body::body::Body`
   |
   = help: items from traits can only be used if the trait is in scope
help: the following trait is implemented but not in scope; perhaps add a `use` for it:
   |
2  | use futures::TryStreamExt;
   |

error: aborting due to 2 previous errors

Some errors have detailed explanations: E0432, E0599.
For more information about an error, try `rustc --explain E0432`.
error: could not compile `simple_experiment`.

To learn more, run the command again with --verbose.
```

## Now
it compiles correctly