### PR TITLE
Fix example in basic.md

### DIFF
--- a/_guides/client/basic.md
+++ b/_guides/client/basic.md
@@ -65,7 +65,7 @@ let client = Client::new();
 let uri = "http://httpbin.org/ip".parse()?;
 
 // Await the response...
-let resp = client.get(uri).await?;
+let mut resp = client.get(uri).await?;
 
 println!("Response: {}", resp.status());
 # Ok(())


### PR DESCRIPTION
The resp in the first codeblock was incorrectly declared as 
immutable. Only the second example was correct.