### PR TITLE
Link to latest TechEmpower benchmarks

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -19,7 +19,7 @@
         <ul>
             <li>A <strong>Client</strong> for talking to web services.</li>
             <li>A <strong>Server</strong> for building those web services.</li>
-            <li>Blazing <strong>fast</strong><a href="https://www.techempower.com/benchmarks/#section=data-r18&hw=ph&test=plaintext">*</a> thanks to Rust.</li>
+            <li>Blazing <strong>fast</strong><a href="https://www.techempower.com/benchmarks/#section=data-r20&hw=ph&test=plaintext">*</a> thanks to Rust.</li>
             <li>High <strong>concurrency</strong> with non-blocking sockets.</li>
             <li>HTTP/1 and <strong>HTTP/2</strong> support.</li>
         </ul>


### PR DESCRIPTION
The link now points to the latest round, R20, from 2021-02-08. The link
previous pointed to R18 which was from 2019 and nearly 3 years old.