### PR TITLE
feat: fix broken links

### DIFF
--- a/.github/workflows/contrib.yml
+++ b/.github/workflows/contrib.yml
@@ -29,8 +29,8 @@ jobs:
       - name: Copy CONTRIBUTING.md into docs
         run: |
           sed -i -e 's|./docs/||g' hyper/CONTRIBUTING.md
-          cp -a hyper/CONTRIBUTING.md hyper/docs
-      
+          cp -a hyper/CONTRIBUTING.md hyper/docs/CONTRIBUTING.md
+
       # Insert frontmatter borders, replace markdown header with
       # frontmatter title and insert layout: guide
       - name: Convert doc titles to frontmatter 
@@ -49,8 +49,9 @@ jobs:
           sed -i -e '4i permalink: /contrib/' hyper/docs/README.md
           mv hyper/docs/README.md hyper/docs/index.md
 
-      # Lowercase the internal links so they will correctly point to
-      # the lowercased filenames.
+
+      # Lowercase the internal links and replace underscores with
+      # hyphens, so they will point to the correct file.
       - name: Lowercase internal links
         run: |
           for filename in hyper/docs/*.md; do
@@ -58,14 +59,24 @@ jobs:
             filename=${filename::-3};
 
             for file in hyper/docs/*.md; do
+              # filename without parent path
+              filename=${filename##*/}
+
               # don't lowercase MSRV
-              if [[ "${filename##*/}" == 'MSRV' ]]; then
+              if [[ "${filename}" == 'MSRV' ]]; then
                 continue
               fi
 
-              # match instances of only the filename, not including
-              # the parent path, and convert them to lowercase
-              sed -i -e "s|${filename##*/}|\L\0|g" $file;
+              # lowercase filenames
+              sed -i -e "s|${filename}|${filename,,}|g" $file;
+
+              # match on the lowercased filename from here on
+              lowercased=${filename,,}
+
+              hyphenated=${lowercased//_/-}
+
+              # replace underscores in internal links with hyphens
+              sed -i -e "s|${lowercased}|${hyphenated}|g" $file;
             done
           done
 
@@ -75,7 +86,7 @@ jobs:
             mv -vn "$f" "$(echo "$f" | tr '[:upper:]' '[:lower:]' | tr '_' '-')"; 
           done
 
-      - name: Copy docs to contrib
+      - name: Copy the hyper docs to contrib
         run: |  
           mkdir -p _contrib
           cp -a hyper/docs/. _contrib/

--- a/_contrib/contributing.md
+++ b/_contrib/contributing.md
@@ -8,7 +8,7 @@ You want to contribute? You're awesome! Don't know where to start? Check the [li
 [easy tag]: https://github.com/hyperium/hyper/issues?q=label%3AE-easy+is%3Aopen
 
 
-## [Pull Requests](pull_requests.md)
+## [Pull Requests](pull-requests.md)
 
-- [Submitting a Pull Request](pull_requests.md#submitting-a-pull-request)
+- [Submitting a Pull Request](pull-requests.md#submitting-a-pull-request)
 - [Commit Guidelines](commits.md)

--- a/_contrib/governance.md
+++ b/_contrib/governance.md
@@ -109,6 +109,6 @@ Maintainers are the project admins. Besides being a collaborator, they take care
 of house-keeping duties, help lead the direction, and have the final authority when
 required.
 
-[coc]: ./code_of_conduct.md
+[coc]: ./code-of-conduct.md
 [contrib]: ../contributing.md
 [triage-guide]: ./issues.md#triaging

--- a/_contrib/issues.md
+++ b/_contrib/issues.md
@@ -112,6 +112,6 @@ The severity marks how _severe_ the issue is. Note this isn't "importance" or "p
 - **S-refactor**: improve internal code to help readability and maintenance.
 
 [issues]: https://github.com/hyperium/hyper/issues
-[COC]: ./code_of_conduct.md
-[PRs]: ./pull_requests.md
+[COC]: ./code-of-conduct.md
+[PRs]: ./pull-requests.md
 [MRE]: https://en.wikipedia.org/wiki/Minimal_reproducible_example

--- a/_contrib/tenets.md
+++ b/_contrib/tenets.md
@@ -20,7 +20,7 @@ community building and using it. All contributions are in the open. We don't
 maintain private versions, and don't include features that aren't useful to
 others.
 
-[We prioritize kindness](./code_of_conduct.md), compassion and empathy towards all
+[We prioritize kindness](./code-of-conduct.md), compassion and empathy towards all
 contributors. Technical skill is not a substitute for human decency.
 
 ### Examples


### PR DESCRIPTION
A few links were broken by not having their underscores replaced with hyphens, meaning they weren't matching the filenames. This change makes sure all internal link underscores are replaced with hyphens, and the first PR that applies the updated script is included.