### PR TITLE
ci: fix broken links to contributing

### DIFF
--- a/.github/workflows/contrib.yml
+++ b/.github/workflows/contrib.yml
@@ -55,6 +55,10 @@ jobs:
       - name: Lowercase internal links
         run: |
           for filename in hyper/docs/*.md; do
+            # since we move some docs from hyper root into the docs folder,
+            # fix links to them
+            sed -i -e 's|\.\./|\./|g' $filename;
+
             # cut `.md` from the filename before search and replace
             filename=${filename::-3};
 


### PR DESCRIPTION
This should fix the last of the broken links. I didn't include the bot PR in this since I think it's a good opportunity to see it in action on the main repo. But to see that this fix is correct, here is the PR in my fork: https://github.com/oddgrd/hyperium.github.io/pull/6/files