### PR TITLE
chore: v1.0.0-rc.3

### DIFF
--- a/.github/workflows/check_guides.sh
+++ b/.github/workflows/check_guides.sh
@@ -19,7 +19,7 @@ EOF
         fi
         if [ $value = stable ]; then
             cat >> "$value/Cargo.toml" <<-EOF
-    hyper = { version = "1.0.0-rc.2", features = ["full"] }
+    hyper = { version = "1.0.0-rc.3", features = ["full"] }
     tokio = { version = "1", features = ["full"] }
     http-body-util = "0.1.0-rc.2" 
 EOF

--- a/_config.yml
+++ b/_config.yml
@@ -53,7 +53,7 @@ relative_links:
 plugins:
   - jekyll-redirect-from
   
-docs_url: https://docs.rs/hyper/1.0.0-rc.2
+docs_url: https://docs.rs/hyper/1.0.0-rc.3
 examples_url: https://github.com/hyperium/hyper/tree/master/examples
 http_body_util_url: https://docs.rs/http-body-util/0.1.0-rc.2
 hyper_tls_url: https://docs.rs/hyper-tls/*

--- a/_stable/client/basic.md
+++ b/_stable/client/basic.md
@@ -11,7 +11,7 @@ Let's tell Cargo about our dependencies by having this in the Cargo.toml.
 
 ```toml
 [dependencies]
-hyper = { version = "1.0.0-rc.2", features = ["full"] }
+hyper = { version = "1.0.0-rc.3", features = ["full"] }
 tokio = { version = "1", features = ["full"] }
 http-body-util = "0.1.0-rc.2"
 ```

--- a/_stable/index.md
+++ b/_stable/index.md
@@ -13,7 +13,7 @@ You can start using it by first adding it to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-hyper = { version = "1.0.0-rc.2", features = ["full"] }
+hyper = { version = "1.0.0-rc.3", features = ["full"] }
 ```
 
 - If building a web server, continue with the [Server guide][].

--- a/_stable/server/hello-world.md
+++ b/_stable/server/hello-world.md
@@ -9,7 +9,7 @@ First we need to declare our dependencies, let's add the following to our `Cargo
 
 ```toml
 [dependencies]
-hyper = { version = "1.0.0-rc.2", features = ["full"] }
+hyper = { version = "1.0.0-rc.3", features = ["full"] }
 tokio = { version = "1", features = ["full"] }
 http-body-util = "0.1.0-rc.2" 
 ```


### PR DESCRIPTION
Congrats on the release, one step closer :partying_face:. I saw you added the legacy client to hyper-util as well, should we use it in the advanced guide: https://github.com/hyperium/hyperium.github.io/pull/77? The sending of requests in parallel part could be made a lot simpler with the legacy client (and it may not be correct currently :sweat_smile:).