### PR TITLE
chore(site): edit GitHub links (#3210)

### DIFF
--- a/.github/workflows/contrib.yml
+++ b/.github/workflows/contrib.yml
@@ -49,7 +49,7 @@ jobs:
       # This adjustment links the correct source file.
       - name: Retain correct CONTRIBUTING.md path
         run: |
-          sed -i -e '4s/docs\///' docs/CONTRIBUTING.md
+          sed -i -e '4s/docs\///' hyper/docs/CONTRIBUTING.md
 
       # Use the hyper docs readme as the index page of contrib,
       # and insert permalink: /contrib/ in the frontmatter

--- a/.github/workflows/contrib.yml
+++ b/.github/workflows/contrib.yml
@@ -81,7 +81,7 @@ jobs:
               fi
 
               # lowercase filenames outside frontmatter
-              sed -i -e "1,4!s|${filename}|${filename,,}|g" $file;
+              sed -i -e "1,/^---$/!s|${filename}|${filename,,}|g" $file;
 
               # match on the lowercased filename from here on
               lowercased=${filename,,}

--- a/.github/workflows/contrib.yml
+++ b/.github/workflows/contrib.yml
@@ -32,15 +32,24 @@ jobs:
           cp -a hyper/CONTRIBUTING.md hyper/docs/CONTRIBUTING.md
 
       # Insert frontmatter borders, replace markdown header with
-      # frontmatter title and insert layout: guide
+      # frontmatter title and insert: 
+      #   - layout: guide
+      #   - hyper_path: {path}
       - name: Convert doc titles to frontmatter 
         run: |
           for f in hyper/docs/*.md; do
             sed -i -e '1i ---' \
             -e '1s/#/title:/' \
             -e '2i layout: guide' \
+            -e '2i hyper_path: ${f:2}' \
             -e '2i ---' $f;
           done
+
+      # CONTRIBUTING.md is uniquely copied into the docs folder.
+      # This adjustment links the correct source file.
+      - name: Retain correct CONTRIBUTING.md path
+        run: |
+          sed -i -e '4s/docs\///' docs/CONTRIBUTING.md
 
       # Use the hyper docs readme as the index page of contrib,
       # and insert permalink: /contrib/ in the frontmatter

--- a/.github/workflows/contrib.yml
+++ b/.github/workflows/contrib.yml
@@ -41,7 +41,7 @@ jobs:
             sed -i -e '1i ---' \
             -e '1s/#/title:/' \
             -e '2i layout: guide' \
-            -e "2i hyper_path: ${f:2}" \
+            -e "2i hyper_path: ${f:6}" \
             -e '2i ---' $f;
           done
 

--- a/.github/workflows/contrib.yml
+++ b/.github/workflows/contrib.yml
@@ -41,7 +41,7 @@ jobs:
             sed -i -e '1i ---' \
             -e '1s/#/title:/' \
             -e '2i layout: guide' \
-            -e '2i hyper_path: ${f:2}' \
+            -e "2i hyper_path: ${f:2}" \
             -e '2i ---' $f;
           done
 

--- a/.github/workflows/contrib.yml
+++ b/.github/workflows/contrib.yml
@@ -80,8 +80,8 @@ jobs:
                 continue
               fi
 
-              # lowercase filenames
-              sed -i -e "s|${filename}|${filename,,}|g" $file;
+              # lowercase filenames outside frontmatter
+              sed -i -e "1,4!s|${filename}|${filename,,}|g" $file;
 
               # match on the lowercased filename from here on
               lowercased=${filename,,}

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -3,9 +3,15 @@
         <div class="row">
             <div class="col-sm-6 text-center text-sm-left text-muted">&copy; 2023 hyper</div>
             <div class="col-sm-6 text-center text-sm-right">
-                <a href="https://github.com/hyperium/hyperium.github.io/blob/master/{{ page.path }}">
-                    edit this page on github
-                </a>
+                {% if page.hyper_path %}
+                    <a href="https://github.com/hyperium/hyper/blob/master/{{ page.hyper_path }}">
+                        edit this page on github
+                    </a>
+                {% else %}
+                    <a href="https://github.com/hyperium/hyperium.github.io/blob/master/{{ page.path }}">
+                        edit this page on github
+                    </a>
+                {% endif %}
             </div>
         </div>
     </div>


### PR DESCRIPTION
# Overview

Populate a new page field 'hyper_path' for copied contrib files. Conditionally link back to [hyper](https://github.com/hyperium/hyper) if a 'hyper_path' is present, otherwise continue to reference [hyperium.github.io](https://github.com/hyperium/hyperium.github.io) (relevant for all collections besides contrib).

Addresses hyperium/hyper#3210

# Thought process

There are several interesting manipulations that happen within [contrib.yml](https://github.com/hyperium/hyperium.github.io/blob/da1d0e45d37042f637102fdf5fa5cbae23973737/.github/workflows/contrib.yml). These new additions should account for files that are:
- renamed <sm>(README -> index)</sm>
- copied / moved <sm>(CONTRIBUTING -> docs/contributing)</sm>
- in a separate repository (specifically [hyper](https://github.com/hyperium/hyper))

# Testing

I've been testing these changes in remote containers, but I'm interested to verify with the real workflow 🧪 🔬 

# Criticism Welcome 😄 

I thrive on feedback, please let me know if you'd like to see any changes to meet the criteria 👍🏻 