### PR TITLE
Wait for the sender to  be ready

### DIFF
--- a/_stable/client/basic.md
+++ b/_stable/client/basic.md
@@ -106,6 +106,7 @@ tokio::task::spawn(async move {
 #     .uri(url)
 #     .header(hyper::header::HOST, authority.as_str())
 #     .body(Empty::<Bytes>::new())?;
+# sender.ready().await?;
 # let mut res = sender.send_request(req).await?;
 # Ok(())
 # }
@@ -153,6 +154,7 @@ let req = Request::builder()
     .body(Empty::<Bytes>::new())?;
 
 // Await the response...
+sender.ready().await?;
 let mut res = sender.send_request(req).await?;
 
 println!("Response status: {}", res.status());
@@ -205,6 +207,7 @@ use tokio::io::{stdout, AsyncWriteExt as _};
 # .uri(url)
 # .header(hyper::header::HOST, authority.as_str())
 # .body(Empty::<Bytes>::new())?;
+# sender.ready().await?;
 # let mut res = sender.send_request(req).await?;
 // Stream the body, writing each frame to stdout as it arrives
 while let Some(next) = res.frame().await {


### PR DESCRIPTION
I adopted the given example in my own code, however, I was receiving occasional error messages because the connection was not ready. This should help API users encountering the same error.

I wonder also if you might consider changing the API to reflect the necessity of using `sender.ready()` before dispatching a request. Rust, as a language and ecosystem, (as I'm sure you know) often provides compile-time guarantees so that call patterns must reflect contracts. It would be ideal to have a compile-time constraint hat enforces the inability to use a sender before it is ready. Perhaps the `handshake` method should return `(impl Future<Output=Sender>, Connection)` instead of simply `(Sender, Connection)`.