### PR TITLE
chore: update hyper crates, use hyper io traits

### DIFF
--- a/.github/workflows/check_guides.sh
+++ b/.github/workflows/check_guides.sh
@@ -19,9 +19,10 @@ EOF
         fi
         if [ $value = stable ]; then
             cat >> "$value/Cargo.toml" <<-EOF
-    hyper = { version = "1.0.0-rc.3", features = ["full"] }
+    hyper = { version = "1.0.0-rc.4", features = ["full"] }
     tokio = { version = "1", features = ["full"] }
-    http-body-util = "0.1.0-rc.2" 
+    http-body-util = "0.1.0-rc.3" 
+    hyper-util = { git = "https://github.com/hyperium/hyper-util.git" }
 EOF
             cargo build --manifest-path "$value/Cargo.toml"
         fi

--- a/_config.yml
+++ b/_config.yml
@@ -53,9 +53,9 @@ relative_links:
 plugins:
   - jekyll-redirect-from
   
-docs_url: https://docs.rs/hyper/1.0.0-rc.3
+docs_url: https://docs.rs/hyper/1.0.0-rc.4
 examples_url: https://github.com/hyperium/hyper/tree/master/examples
-http_body_util_url: https://docs.rs/http-body-util/0.1.0-rc.2
+http_body_util_url: https://docs.rs/http-body-util/0.1.0-rc.3
 hyper_tls_url: https://docs.rs/hyper-tls/*
 
 futures_url: https://docs.rs/futures/0.3.*

--- a/_stable/index.md
+++ b/_stable/index.md
@@ -13,7 +13,7 @@ You can start using it by first adding it to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-hyper = { version = "1.0.0-rc.3", features = ["full"] }
+hyper = { version = "1.0.0-rc.4", features = ["full"] }
 ```
 
 - If building a web server, continue with the [Server guide][].


### PR DESCRIPTION
Hey! This just updates hyper to rc4 and http-body-util to rc3, and it changes the guides to use the new hyper io traits from hyper-util via a git dependency. Tests pass locally.

Also congrats on going full-time open-source, that's very exciting news! :partying_face: 