### PR TITLE
guide: add runtime to _data

### DIFF
--- a/_data/stable.yml
+++ b/_data/stable.yml
@@ -10,6 +10,7 @@
   path: "/init"
   guides:
   - setup
+  - runtime
 
 - title: Server
   path: "/server"


### PR DESCRIPTION
This PR allows `runtime` to show in the navigation bar

https://hyper.rs/guides/1/init/runtime/