### PR TITLE
Update basic.md example to set path

### DIFF
--- a/_stable/client/basic.md
+++ b/_stable/client/basic.md
@@ -112,7 +112,7 @@ tokio::task::spawn(async move {
 });
 # let authority = url.authority().unwrap().clone();
 # let req = Request::builder()
-#     .uri(url)
+#     .uri(url.path())
 #     .header(hyper::header::HOST, authority.as_str())
 #     .body(Empty::<Bytes>::new())?;
 # let mut res = sender.send_request(req).await?;
@@ -160,7 +160,7 @@ let authority = url.authority().unwrap().clone();
 
 // Create an HTTP request with an empty body and a HOST header
 let req = Request::builder()
-    .uri(url)
+    .uri(url.path())
     .header(hyper::header::HOST, authority.as_str())
     .body(Empty::<Bytes>::new())?;
 
@@ -217,9 +217,9 @@ use tokio::io::{AsyncWriteExt as _, self};
 # });
 # let authority = url.authority().unwrap().clone();
 # let req = Request::builder()
-# .uri(url)
-# .header(hyper::header::HOST, authority.as_str())
-# .body(Empty::<Bytes>::new())?;
+#     .uri(url.path())
+#     .header(hyper::header::HOST, authority.as_str())
+#     .body(Empty::<Bytes>::new())?;
 # let mut res = sender.send_request(req).await?;
 // Stream the body, writing each frame to stdout as it arrives
 while let Some(next) = res.frame().await {


### PR DESCRIPTION
Send the path to the URI field instead of the whole URI.

The goal is to make it works with unnamed server like local one `127.0.0.1:8080` or servers unaware of they own name (or alternative name). 

I do not see any drawback to that change and I think it maybe more user-friendly to use relative URI here.

Edit: Oupsy ! I see one. The query part is missing.
I should have use path_and_query instead of path only. But it make it a lot more complex with something like that:

```rust
    let req = Request::builder()
        .uri(hyper::Uri::from_parts({
            let mut uri_ = <http::uri::Parts as std::default::Default>::default();
            uri_.path_and_query = url.path_and_query().cloned();
            uri_
        })?)
        .header(hyper::header::HOST, authority.as_str())
        .body(Empty::<Bytes>::new())?;
```

Maybe we can have something in between or maybe the initial code is well enough. 
Thank you.