### PR TITLE
Fix broken links

### DIFF
--- a/_layouts/guide.html
+++ b/_layouts/guide.html
@@ -38,7 +38,7 @@
                 <a href="{{ site.legacy_docs_url }}">API Reference</a>
               {% elsif page.collection == "stable" %}
                 <a href="{{ site.examples_url }}/README.md">Additional Examples</a>
-                <a href="{{ site.docs_url }}">API Reference</a>
+                <a href="{{ site.hyper_docs_url }}">API Reference</a>
               {% endif %}
             </h4>
           </nav>

--- a/_stable/client/basic.md
+++ b/_stable/client/basic.md
@@ -236,12 +236,12 @@ And that's it! You can see the [full example here][example].
 
 [Tokio]: https://tokio.rs
 [Tokio-Futures]: https://tokio.rs/tokio/tutorial/async
-[StatusCode]: {{ site.docs_url }}/hyper/struct.StatusCode.html
-[Response]: {{ site.docs_url }}/hyper/struct.Response.html
-[Request]: {{ site.docs_url }}/hyper/struct.Request.html
-[Connection]: {{ site.docs_url }}/hyper/client/conn/http1/struct.Connection.html
-[SendRequest]: {{ site.docs_url }}/hyper/client/conn/http1/struct.SendRequest.html
-[Frame]: {{ site.docs_url }}/hyper/body/struct.Frame.html
+[StatusCode]: {{ site.hyper_docs_url }}/hyper/struct.StatusCode.html
+[Response]: {{ site.hyper_docs_url }}/hyper/struct.Response.html
+[Request]: {{ site.hyper_docs_url }}/hyper/struct.Request.html
+[Connection]: {{ site.hyper_docs_url }}/hyper/client/conn/http1/struct.Connection.html
+[SendRequest]: {{ site.hyper_docs_url }}/hyper/client/conn/http1/struct.SendRequest.html
+[Frame]: {{ site.hyper_docs_url }}/hyper/body/struct.Frame.html
 [Empty]: {{ site.http_body_util_url }}/http_body_util/struct.Empty.html
 
 [example]: {{ site.examples_url }}/client.rs

--- a/_stable/index.md
+++ b/_stable/index.md
@@ -16,6 +16,6 @@ setup](init/setup).
 
 You could also look at the [generated API documentaton][docs].
 
-[docs]: {{ site.docs_url }}
+[docs]: {{ site.hyper_docs_url }}
 [Server guide]: server/hello-world
 [Client guide]: client/basic


### PR DESCRIPTION
The links in the "Getting Started" page are broken: https://hyper.rs/guides/1/
![image](https://github.com/hyperium/hyperium.github.io/assets/10438726/89eb66e9-1884-4ba9-a007-b7241e5642ea)

This fixes them:
![image](https://github.com/hyperium/hyperium.github.io/assets/10438726/5dcd6527-e8f8-4e12-a0cc-1d8ecd006a7e)

It also fixes some other instances of broken links, for example `Request` on this page: https://hyper.rs/guides/1/client/basic/#setup

