### PR TITLE
Fix the missing url in basic.md

### DIFF
--- a/_stable/client/basic.md
+++ b/_stable/client/basic.md
@@ -237,8 +237,8 @@ And that's it! You can see the [full example here][example].
 [Tokio]: https://tokio.rs
 [Tokio-Futures]: https://tokio.rs/tokio/tutorial/async
 [StatusCode]: {{ site.hyper_docs_url }}/hyper/struct.StatusCode.html
-[Response]: {{ site.hyper_docs_url }}/hyper/struct.Response.html
-[Request]: {{ site.hyper_docs_url }}/hyper/struct.Request.html
+[Response]: {{ site.http_docs_url }}/http/request/struct.Request.html
+[Request]: {{ site.http_docs_urll }}/http/response/index.html
 [Connection]: {{ site.hyper_docs_url }}/hyper/client/conn/http1/struct.Connection.html
 [SendRequest]: {{ site.hyper_docs_url }}/hyper/client/conn/http1/struct.SendRequest.html
 [Frame]: {{ site.hyper_docs_url }}/hyper/body/struct.Frame.html

--- a/_stable/client/basic.md
+++ b/_stable/client/basic.md
@@ -237,8 +237,8 @@ And that's it! You can see the [full example here][example].
 [Tokio]: https://tokio.rs
 [Tokio-Futures]: https://tokio.rs/tokio/tutorial/async
 [StatusCode]: {{ site.hyper_docs_url }}/hyper/struct.StatusCode.html
-[Response]: {{ site.http_docs_url }}/http/request/struct.Request.html
-[Request]: {{ site.http_docs_urll }}/http/response/index.html
+[Response]: {{ site.http_docs_url }}/http/response/struct.Response.html
+[Request]: {{ site.http_docs_url }}/http/request/struct.Request.html
 [Connection]: {{ site.hyper_docs_url }}/hyper/client/conn/http1/struct.Connection.html
 [SendRequest]: {{ site.hyper_docs_url }}/hyper/client/conn/http1/struct.SendRequest.html
 [Frame]: {{ site.hyper_docs_url }}/hyper/body/struct.Frame.html


### PR DESCRIPTION
This pull request includes a small change to the `_stable/client/basic.md` file. The change updates the URLs for the `Response` and `Request` references to point to the correct documentation pages.

Documentation updates:

* [`_stable/client/basic.md`](diffhunk://#diff-5b94a577a3e6091b2b9fa1a858cbb66782fc679a15d5af646c03702fc0978b83L240-R241): Updated the URLs for `Response` and `Request` references to point to the correct HTTP documentation pages.