### PR TITLE
fix example in graceful-shutdown.md: add `drop(listener)`

### DIFF
--- a/_stable/server/graceful-shutdown.md
+++ b/_stable/server/graceful-shutdown.md
@@ -88,6 +88,7 @@ loop {
         },
 
         _ = &mut signal => {
+            drop(listener);
             eprintln!("graceful shutdown signal received");
             // stop the accept loop
             break;


### PR DESCRIPTION
Need to drop the listener for the graceful shutdown to fully succeed. Otherwise, even though we cannot `curl` the server addr, `netstat` still shows the process listening. This will align the example with the hyper-util example in: https://github.com/hyperium/hyper-util/blob/e74ab7888638e768de17c47ed5f20c8b623a308f/examples/server_graceful.rs#L47